### PR TITLE
cob: Add -tags support for ad-hoc build tags.

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ type config struct {
 	bench          string
 	benchmem       bool
 	benchtime      string
+	tags           string
 }
 
 func newConfig(c *cli.Context) config {
@@ -19,5 +20,6 @@ func newConfig(c *cli.Context) config {
 		bench:          c.String("bench"),
 		benchmem:       c.Bool("benchmem"),
 		benchtime:      c.String("benchtime"),
+		tags:           c.String("tags"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -54,6 +54,10 @@ func main() {
 				Usage: "Run enough iterations of each benchmark to take t, specified as a time.Duration (for example, -benchtime 1h30s).",
 				Value: "1s",
 			},
+			&cli.StringFlag{
+				Name:  "tags",
+				Usage: "Run only those benchmarks with the specified build tags.",
+			},
 		},
 	}
 
@@ -166,6 +170,9 @@ func prepareBenchArgs(c config) []string {
 	args := []string{"test", "-benchtime", c.benchtime, "-bench", c.bench}
 	if c.benchmem {
 		args = append(args, "-benchmem")
+	}
+	if c.tags != "" {
+		args = append(args, "-tags", c.tags)
 	}
 	args = append(args, c.args...)
 	return args


### PR DESCRIPTION

*Description of changes:*
This PR adds support for passing in ad-hoc build time tags with `-tags` flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Simarpreet Singh <simar@linux.com>