### PR TITLE
Changed: New arg for specify git path

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type config struct {
 	compare        []string
 	benchCmd       string
 	benchArgs      []string
+	gitPath        string
 }
 
 func newConfig(c *cli.Context) config {
@@ -23,5 +24,6 @@ func newConfig(c *cli.Context) config {
 		compare:        strings.Split(c.String("compare"), ","),
 		benchCmd:       c.String("bench-cmd"),
 		benchArgs:      strings.Fields(c.String("bench-args")),
+		gitPath:        c.String("git-path"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -66,6 +66,11 @@ func main() {
 				Usage: "Specify arguments passed to -cmd",
 				Value: "test -run '^$' -bench . -benchmem ./...",
 			},
+			&cli.StringFlag{
+				Name:  "git-path",
+				Usage: "Specify the path of the git repo",
+				Value: ".",
+			},
 		},
 	}
 
@@ -76,7 +81,7 @@ func main() {
 }
 
 func run(c config) error {
-	r, err := git.PlainOpen(".")
+	r, err := git.PlainOpen(c.gitPath)
 	if err != nil {
 		return xerrors.Errorf("unable to open the git repository: %w", err)
 	}


### PR DESCRIPTION
*Description of changes:*

New argument to be able to specify where is the path of the git repo.

Example usage : `cob --git-path ../`

Useful when running tests outside the project root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
