### PR TITLE
Use native golangci-lint-action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,14 +14,6 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
-    
-    - name: Install GolangCI-Lint
-      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $version
-      env:
-        version: v1.22.2
-
-    - name: Lint
-      run: ./bin/golangci-lint run
           
     - name: Test
       run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.13'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54


### PR DESCRIPTION
*Description of changes:*
This moves the golangci-lint step out of the main build and test pipeline thus parallelizing the execution. This leverages the official [golangci-lint-action](https://github.com/golangci/golangci-lint-action) which also provides native Github error reporting.
![image](https://github.com/knqyf263/cob/assets/45375059/6e275608-5a5b-4a03-a2e8-457e1ca7fc86)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
