### PR TITLE
Fix golancgi-lint go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.13'
+          go-version: '1.21'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
*Description of changes:*
In #30 I forgot to also update the go version in the golangci-lint workflow. This will fix #35, #36 and #37.
The PRs each need a `@dependabot rebase` afterwards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
