### PR TITLE
Add option to fail on empty results

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,23 +7,25 @@ import (
 )
 
 type config struct {
-	onlyDegression bool
-	threshold      float64
-	base           string
-	compare        []string
-	benchCmd       string
-	benchArgs      []string
-	gitPath        string
+	onlyDegression     bool
+	failWithoutResults bool
+	threshold          float64
+	base               string
+	compare            []string
+	benchCmd           string
+	benchArgs          []string
+	gitPath            string
 }
 
 func newConfig(c *cli.Context) config {
 	return config{
-		onlyDegression: c.Bool("only-degression"),
-		threshold:      c.Float64("threshold"),
-		base:           c.String("base"),
-		compare:        strings.Split(c.String("compare"), ","),
-		benchCmd:       c.String("bench-cmd"),
-		benchArgs:      strings.Fields(c.String("bench-args")),
-		gitPath:        c.String("git-path"),
+		onlyDegression:     c.Bool("only-degression"),
+		failWithoutResults: c.Bool("fail-without-results"),
+		threshold:          c.Float64("threshold"),
+		base:               c.String("base"),
+		compare:            strings.Split(c.String("compare"), ","),
+		benchCmd:           c.String("bench-cmd"),
+		benchArgs:          strings.Fields(c.String("bench-args")),
+		gitPath:            c.String("git-path"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ func main() {
 				Name:  "only-degression",
 				Usage: "Show only benchmarks with worse score",
 			},
+			&cli.BoolFlag{
+				Name:  "fail-without-results",
+				Usage: "Exit with an error if the parsing fails",
+			},
 			&cli.Float64Flag{
 				Name:  "threshold",
 				Usage: "The program fails if the benchmark gets worse than the threshold",
@@ -144,6 +148,15 @@ func run(c config) error {
 	headSet, err := runBenchmark(c.benchCmd, c.benchArgs)
 	if err != nil {
 		return xerrors.Errorf("failed to run a benchmark: %w", err)
+	}
+
+	if c.failWithoutResults {
+		if len(prevSet) == 0 {
+			return xerrors.New("could not parse any benchmark results for the previous commit")
+		}
+		if len(headSet) == 0 {
+			return xerrors.New("could not parse any benchmark results for the current commit")
+		}
 	}
 
 	var ratios []result


### PR DESCRIPTION
*Description of changes:*
I am running `cob` as part of a CI pipeline and we encountered the issue that our benchmarks sometimes produced malformed logs that could not be parsed. But since these logs did not contain any results and thus no slowdowns `cob` failed quietly and the pipeline did not get blocked.
To prevent such issues I added the `-fail-without-results` flag which will cause it to error out in such cases. I would even argue that this could be the default, but that would then be a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.